### PR TITLE
docs: Fix timeout vs probe_timeout

### DIFF
--- a/docs/src/processes.md
+++ b/docs/src/processes.md
@@ -175,9 +175,10 @@ All probe types support these timing options:
       http.get = { port = 8080; path = "/health"; };
       initial_delay = 2;    # seconds before first probe (default: 0)
       period = 10;           # seconds between probes (default: 10)
-      timeout = 1;           # seconds before probe times out (default: 1)
+      probe_timeout = 1;           # seconds before probe times out (default: 1)
       success_threshold = 1; # consecutive successes needed (default: 1)
       failure_threshold = 3; # consecutive failures before unhealthy (default: 3)
+      # timeout = ; Overall deadline in seconds for the process to become ready. null = no deadline.
     };
   };
 }

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -3577,7 +3577,7 @@ string
 *Default:*
 
 ```nix
-"2.0.6"
+"2.1.0"
 ```
 
 *Declared by:*


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Ready Probe timing configuration: the timeout option replaced by probe_timeout (defaults to 1 second); related comment updated.
  * Bumped documentation version reference from 2.0.6 to 2.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->